### PR TITLE
[WIP] Coherence theorem

### DIFF
--- a/monoidal_categories/coherence_thm.lean
+++ b/monoidal_categories/coherence_thm.lean
@@ -1,0 +1,397 @@
+import .monoidal_category
+import ..util.data.nonempty_list
+import ..util.data.bin_tree
+import ..util.data.bin_tree.cong_clos
+
+open tqft.categories
+open tqft.categories.monoidal_category
+open tqft.util.data.nonempty_list
+open tqft.util.data.bin_tree
+open tqft.util.data.bin_tree.bin_tree
+
+namespace tqft.categories.monoidal_category.coherence_thm
+
+universes u v
+
+variable {α : Type u}
+
+inductive reassoc_dir_single_step : bin_tree α → bin_tree α → Type u
+| rotate_right : Π r s t, reassoc_dir_single_step (branch (branch r s) t) (branch r (branch s t))
+
+namespace reassoc_dir_single_step
+
+lemma respects_to_list : Π (s t : bin_tree α), reassoc_dir_single_step s t → s.to_list = t.to_list
+| ._ ._ (rotate_right _ _ _) :=
+    begin
+      unfold bin_tree.to_list,
+      rewrite nonempty_list.append_assoc
+    end
+
+end reassoc_dir_single_step
+
+@[reducible] def reassoc_dir_step : bin_tree α → bin_tree α → Type u :=
+  cong_clos_step reassoc_dir_single_step
+
+namespace reassoc_dir_step
+
+lemma respects_lopsided {s t : bin_tree α} (p : reassoc_dir_step s t) : s.lopsided = t.lopsided :=
+  cong_clos_step.respects_lopsided reassoc_dir_single_step.respects_to_list p
+
+end reassoc_dir_step
+
+@[reducible] def reassoc_dir : bin_tree α → bin_tree α → Type u :=
+  cong_clos reassoc_dir_single_step
+
+@[reducible] def reassoc_dir' : bin_tree α → bin_tree α → Type u :=
+  cong_clos' reassoc_dir_single_step
+
+namespace reassoc_dir
+
+@[reducible] def refl (t : bin_tree α) : reassoc_dir t t := cong_clos.refl _ t
+
+def rotate_right (r s t : bin_tree α) : reassoc_dir (branch (branch r s) t) (branch r (branch s t)) :=
+  cong_clos.lift (reassoc_dir_single_step.rotate_right _ _ _)
+
+def lopsided_combine : Π (xs ys : nonempty_list α),
+    reassoc_dir (branch (from_list_lopsided xs) (from_list_lopsided ys)) (from_list_lopsided (xs ++ ys))
+| (nonempty_list.singleton x) ys := refl _
+| (nonempty_list.cons x xs)   ys :=
+  begin
+    simp, unfold from_list_lopsided,
+    apply cong_clos.trans,
+      apply rotate_right,
+      apply cong_clos.cong,
+        apply reassoc_dir.refl,
+        apply lopsided_combine
+  end
+
+def reassoc_lopsided : Π (t : bin_tree α), reassoc_dir t t.lopsided
+| (leaf x)     := refl _
+| (branch l r) :=
+  begin
+    apply cong_clos.trans,
+      apply cong_clos.cong,
+        apply reassoc_lopsided,
+        apply reassoc_lopsided,
+    apply lopsided_combine
+  end
+
+lemma reassoc_already_lopsided :
+    Π (l : nonempty_list α),
+    reassoc_lopsided (bin_tree.from_list_lopsided l) == refl (bin_tree.from_list_lopsided l)
+| (nonempty_list.singleton x) := by reflexivity
+| (nonempty_list.cons x xs)   :=
+    calc
+          cong_clos.trans
+            (cong_clos.inject_right _ (reassoc_lopsided (from_list_lopsided xs)))
+            (refl (branch (leaf x) (from_list_lopsided (to_list (from_list_lopsided xs)))))
+        = cong_clos.inject_right (leaf x) (reassoc_lopsided (from_list_lopsided xs))
+        : by apply cong_clos.trans_refl_right
+    ... == cong_clos.inject_right (leaf x) (refl (from_list_lopsided xs))
+        : begin
+            congr_args,
+              unfold lopsided, rewrite from_list_lopsided_to_list,
+              apply reassoc_already_lopsided
+          end
+    ... == refl (branch (leaf x) (from_list_lopsided xs))
+        : by reflexivity
+
+lemma respects_to_list {s t : bin_tree α} (p : reassoc_dir s t) : s.to_list = t.to_list :=
+  cong_clos.respects_to_list reassoc_dir_single_step.respects_to_list p
+
+lemma respects_lopsided {s t : bin_tree α} (p : reassoc_dir s t) : s.lopsided = t.lopsided :=
+  cong_clos.respects_lopsided reassoc_dir_single_step.respects_to_list p
+
+end reassoc_dir
+
+inductive reassoc_single_step : bin_tree α → bin_tree α → Type u
+| rotate_left  : Π r s t, reassoc_single_step (branch r (branch s t)) (branch (branch r s) t)
+| rotate_right : Π r s t, reassoc_single_step (branch (branch r s) t) (branch r (branch s t))
+
+@[reducible] def reassoc_step : bin_tree α → bin_tree α → Type u :=
+  cong_clos_step reassoc_single_step
+
+@[reducible] def reassoc : bin_tree α → bin_tree α → Type u :=
+  cong_clos reassoc_single_step
+
+namespace reassoc_single_step
+
+def sym : Π (x y : bin_tree α), reassoc_single_step x y → reassoc_single_step y x
+| ._ ._ (rotate_left  _ _ _) := rotate_right _ _ _
+| ._ ._ (rotate_right _ _ _) := rotate_left  _ _ _
+
+lemma respects_to_list : Π (s t : bin_tree α), reassoc_single_step s t → s.to_list = t.to_list
+| ._ ._ (rotate_left _ _ _) :=
+    begin
+      unfold bin_tree.to_list,
+      rewrite nonempty_list.append_assoc
+    end
+| ._ ._ (rotate_right _ _ _) :=
+    begin
+      unfold bin_tree.to_list,
+      rewrite nonempty_list.append_assoc
+    end
+
+end reassoc_single_step
+
+def reassoc_dir_to_reassoc_single_step : Π (s t : bin_tree α), reassoc_dir_single_step s t → reassoc_single_step s t
+| ._ ._ (reassoc_dir_single_step.rotate_right s t u) := reassoc_single_step.rotate_right s t u
+
+def reassoc_dir_to_reassoc : Π {s t : bin_tree α}, reassoc_dir s t → reassoc s t :=
+  λ s t p, cong_clos.transport reassoc_dir_to_reassoc_single_step p
+
+namespace reassoc
+
+@[reducible] def refl (t : bin_tree α) : reassoc_dir t t := cong_clos.refl _ t
+
+def sym : Π {x y : bin_tree α}, reassoc x y → reassoc y x :=
+  λ x y, cong_clos.sym reassoc_single_step.sym
+
+lemma respects_to_list : Π {s t : bin_tree α}, reassoc s t → s.to_list = t.to_list :=
+  λ x y, cong_clos.respects_to_list reassoc_single_step.respects_to_list
+
+def reassoc_lopsided : Π (t : bin_tree α), reassoc t t.lopsided :=
+  λ t, reassoc_dir_to_reassoc (reassoc_dir.reassoc_lopsided t)
+
+-- TODO: more economical construction (with fewer rotations)
+def reassoc_tree : Π (r t : bin_tree α) (h : r.to_list = t.to_list), reassoc r t :=
+begin
+  intros,
+  apply cong_clos.trans,
+  apply reassoc_lopsided,
+  -- TODO: doing `rewrite h` here doesn't work ~> report bug
+  apply sym,
+  unfold lopsided, rewrite h,
+  apply reassoc_lopsided
+end
+
+end reassoc
+
+section interpretation
+
+parameter (C : Category.{u v})
+parameter (M : MonoidalStructure C)
+
+@[reducible] def tensor : C.Obj → C.Obj → C.Obj := λ X Y, M.tensor (X, Y)
+
+local infixl `⟩C⟩`:60 := C.compose
+
+local infix `⊗`:60 := tensor
+
+-- this is better behaved wrt type inference than `M.tensor.onMorphisms` because no tuple has to be inferred
+@[reducible] def tensor_homs : Π {W X Y Z : C.Obj}, C.Hom W X → C.Hom Y Z → C.Hom (W ⊗ Y) (X ⊗ Z) :=
+  λ W X Y Z f g, M.tensor.onMorphisms (f, g)
+
+local infix `⟨⊗⟩`:60 := tensor_homs
+
+open cong_clos
+
+@[reducible] def tensor_tree : bin_tree C.Obj → C.Obj
+| (bin_tree.leaf A)     := A
+| (bin_tree.branch l r) := tensor_tree l ⊗ tensor_tree r
+
+def interpret_cong_clos'
+    {R : bin_tree C.Obj → bin_tree C.Obj → Type u}
+    (I : Π (Xs Ys : bin_tree C.Obj), R Xs Ys → C.Hom (tensor_tree Xs) (tensor_tree Ys))
+    : Π {Xs Ys : bin_tree C.Obj}, cong_clos' R Xs Ys → C.Hom (tensor_tree Xs) (tensor_tree Ys)
+| ._ ._ (cong_clos'.lift _ _ p)       := I _ _ p
+| ._ ._ (cong_clos'.refl ._ t)        := C.identity _
+| ._ ._ (cong_clos'.trans _ _ _ p q)  := C.compose (interpret_cong_clos' p) (interpret_cong_clos' q)
+| ._ ._ (cong_clos'.cong _ _ _ _ l r) := M.tensor.onMorphisms (interpret_cong_clos' l, interpret_cong_clos' r)
+
+-- the equation compiler somehow can't handle the next definitions ~> turn it off
+-- TODO(tim): report bug
+set_option eqn_compiler.lemmas false
+
+-- TODO(tim): factor out I as a variable
+def interpret_cong_clos_step
+    {R : bin_tree C.Obj → bin_tree C.Obj → Type u}
+    (I : Π (Xs Ys : bin_tree C.Obj), R Xs Ys → C.Hom (tensor_tree Xs) (tensor_tree Ys))
+    : Π {Xs Ys : bin_tree C.Obj}, cong_clos_step R Xs Ys → C.Hom (tensor_tree Xs) (tensor_tree Ys)
+| ._ ._ (cong_clos_step.lift x y p)      := I x y p
+| ._ ._ (cong_clos_step.left l₁ l₂ r l)  := interpret_cong_clos_step l ⟨⊗⟩ C.identity (tensor_tree r)
+| ._ ._ (cong_clos_step.right l r₁ r₂ r) := C.identity (tensor_tree l) ⟨⊗⟩ interpret_cong_clos_step r
+
+set_option eqn_compiler.lemmas true
+
+def interpret_cong_clos
+    {R : bin_tree C.Obj → bin_tree C.Obj → Type u}
+    (I : Π (Xs Ys : bin_tree C.Obj), R Xs Ys → C.Hom (tensor_tree Xs) (tensor_tree Ys))
+    : Π {Xs Ys : bin_tree C.Obj}, cong_clos R Xs Ys → C.Hom (tensor_tree Xs) (tensor_tree Ys)
+| ._ ._ (cong_clos.refl ._ t)      := C.identity _
+| ._ ._ (cong_clos.step _ _ _ p q) := C.compose (interpret_cong_clos_step I p) (interpret_cong_clos q)
+
+lemma interpret_cong_clos_functoriality
+    {R : bin_tree C.Obj → bin_tree C.Obj → Type u}
+    (I : Π (Xs Ys : bin_tree C.Obj), R Xs Ys → C.Hom (tensor_tree Xs) (tensor_tree Ys))
+    : Π (Xs Ys Zs : bin_tree C.Obj) (ps : cong_clos R Xs Ys) (qs : cong_clos R Ys Zs),
+      interpret_cong_clos I ps ⟩C⟩ interpret_cong_clos I qs = interpret_cong_clos I (cong_clos.trans ps qs)
+| ._ ._ _ (cong_clos.refl ._ t)       qs := C.left_identity _
+| ._ ._ _ (cong_clos.step _ _ _ p ps) qs :=
+    begin
+      unfold cong_clos.trans,
+      unfold interpret_cong_clos,
+      rewrite C.associativity,
+      rewrite interpret_cong_clos_functoriality
+    end
+
+-- TODO(tim): move this somewhere else?
+lemma functoriality_left
+    (X Y Z A : C.Obj)
+    (f : C.Hom X Y) (g : C.Hom Y Z)
+    : (f ⟩C⟩ g) ⟨⊗⟩ C.identity A = (f ⟨⊗⟩ C.identity A) ⟩C⟩ (g ⟨⊗⟩ C.identity A) := ♮
+
+lemma interpret_cong_clos_inject_left
+    {R : bin_tree C.Obj → bin_tree C.Obj → Type u}
+    (I : Π (Xs Ys : bin_tree C.Obj), R Xs Ys → C.Hom (tensor_tree Xs) (tensor_tree Ys))
+    : Π (Xs Ys Zs : bin_tree C.Obj) (ps : cong_clos R Xs Ys),
+      interpret_cong_clos I (inject_left Zs ps) = interpret_cong_clos I ps ⟨⊗⟩ C.identity (tensor_tree Zs)
+| ._ ._ _ (cong_clos.refl ._ _)       := by {symmetry, apply M.tensor.identities}
+| ._ ._ _ (cong_clos.step _ _ _ p ps) :=
+  begin
+    unfold inject_left,
+    unfold interpret_cong_clos,
+    rewrite functoriality_left,
+    rewrite (interpret_cong_clos_inject_left _ _ _ ps),
+    reflexivity
+  end
+
+-- TODO(tim): it would be cool if interpretation were a real functor from a suitable formal category
+
+def interpret_reassoc_dir_single_step : Π (Xs Ys : bin_tree C.Obj), reassoc_dir_single_step Xs Ys → C.Hom (tensor_tree Xs) (tensor_tree Ys)
+| ._ ._ (reassoc_dir_single_step.rotate_right s t u) := M.associator _ _ _
+
+def interpret_reassoc_dir {Xs Ys : bin_tree C.Obj} : reassoc_dir Xs Ys → C.Hom (tensor_tree Xs) (tensor_tree Ys) :=
+  interpret_cong_clos interpret_reassoc_dir_single_step
+
+lemma interpret_reassoc_dir_functoriality
+    {Xs Ys Zs : bin_tree C.Obj} (ps : reassoc_dir Xs Ys) (qs : reassoc_dir Ys Zs)
+    : interpret_reassoc_dir ps ⟩C⟩ interpret_reassoc_dir qs = interpret_reassoc_dir (cong_clos.trans ps qs)
+  := by apply interpret_cong_clos_functoriality
+
+def interpret_reassoc_dir' {Xs Ys : bin_tree C.Obj} : reassoc_dir' Xs Ys → C.Hom (tensor_tree Xs) (tensor_tree Ys) :=
+  interpret_cong_clos' interpret_reassoc_dir_single_step
+
+def interpret_reassoc_dir_step {Xs Ys : bin_tree C.Obj} : reassoc_dir_step Xs Ys → C.Hom (tensor_tree Xs) (tensor_tree Ys) :=
+  interpret_cong_clos_step interpret_reassoc_dir_single_step
+
+def interpret_reassoc_single_step : Π (Xs Ys : bin_tree C.Obj), reassoc_single_step Xs Ys → C.Hom (tensor_tree Xs) (tensor_tree Ys)
+| ._ ._ (reassoc_single_step.rotate_right s t u) := M.associator _ _ _
+| ._ ._ (reassoc_single_step.rotate_left  s t u) := M.inverse_associator _ _ _
+
+def interpret_reassoc {Xs Ys : bin_tree C.Obj} : reassoc Xs Ys → C.Hom (tensor_tree Xs) (tensor_tree Ys) :=
+  interpret_cong_clos interpret_reassoc_single_step
+
+@[reducible] def to_lopsided (t : bin_tree C.Obj) : C.Hom (tensor_tree t) (tensor_tree t.lopsided) :=
+  interpret_reassoc_dir (reassoc_dir.reassoc_lopsided t)
+
+-- TODO: generalize to cong_clos
+def rewrite_source : Π {s₁ s₂ t : bin_tree α} (eq : s₁ = s₂), reassoc_dir s₁ t → reassoc_dir s₂ t
+| _ ._ _ (eq.refl ._) p := p
+
+-- TODO: generalize to cong_clos
+def rewrite_target : Π {s t₁ t₂ : bin_tree α} (eq : t₁ = t₂), reassoc_dir s t₁ → reassoc_dir s t₂
+| _ ._ _ (eq.refl ._) p := p
+
+-- TODO: generalize to cong_clos
+def rewrite_target_cong : Π {s t₁ t₂ : bin_tree α} (eq : t₁ = t₂) (p : reassoc_dir s t₁), rewrite_target eq p == p
+| _ _ ._ (eq.refl ._) p := heq.refl _
+
+@[reducible] def trans_lopsided' {s t : bin_tree α} (p : reassoc_dir s t) : reassoc_dir s t.lopsided :=
+  cong_clos.trans p (reassoc_dir.reassoc_lopsided t)
+
+-- all roads lead to rome
+def trans_lopsided {s t : bin_tree α} (p : reassoc_dir s t) : reassoc_dir s s.lopsided :=
+  rewrite_target (eq.symm (reassoc_dir.respects_lopsided p)) (trans_lopsided' p)
+
+lemma trans_lopsided_heq {s t : bin_tree α} (p : reassoc_dir s t) : trans_lopsided p == trans_lopsided' p :=
+  by apply rewrite_target_cong
+
+lemma trans_lopsided_already_lopsided {s : bin_tree α} (p : reassoc_dir s s.lopsided) : trans_lopsided p == p :=
+  calc
+         rewrite_target (eq.symm (reassoc_dir.respects_lopsided p)) (cong_clos.trans p (reassoc_dir.reassoc_lopsided s.lopsided))
+      == cong_clos.trans p (reassoc_dir.reassoc_lopsided s.lopsided)
+      : by apply rewrite_target_cong
+  ... == cong_clos.trans p (reassoc_dir.refl s.lopsided)
+      : begin congr_args, rewrite lopsided_idempotent, apply reassoc_dir.reassoc_already_lopsided end
+  ... = p
+      : by apply trans_refl_right
+
+@[reducible] def step_lopsided' {s t : bin_tree α} (p : reassoc_dir_step s t) : reassoc_dir s t.lopsided :=
+  cong_clos.step _ _ _ p (reassoc_dir.reassoc_lopsided t)
+
+def step_lopsided {s t : bin_tree α} (p : reassoc_dir_step s t) : reassoc_dir s s.lopsided :=
+  rewrite_target (eq.symm (reassoc_dir_step.respects_lopsided p)) (step_lopsided' p)
+
+lemma step_lopsided_heq {s t : bin_tree α} (p : reassoc_dir_step s t) : step_lopsided p == step_lopsided' p :=
+  by apply rewrite_target_cong
+
+-- -- TODO(tim): use well-founded induction once lean supports it
+-- -- TODO(tim): why does lean complain that there are missing cases???
+-- meta lemma directed_associator_coherence_thm :
+--     Π (Xs Ys : bin_tree C.Obj) (e : Ys = Xs.lopsided)
+--       (p q : reassoc_dir Xs Ys),
+--       interpret_reassoc_dir p = interpret_reassoc_dir q
+-- | (branch l r) ._ (eq.refl ._) (cong_clos.step ._ ._ ._ (cong_clos_step.left ._ lp ._ p) ps) (cong_clos.step ._ ._ ._ (cong_clos_step.left ._ lq ._ q) qs) :=
+--     have H : Π (l' : bin_tree C.Obj) (f : reassoc_dir_step l l') (fs : reassoc_dir (branch l' r) (branch l r).lopsided),
+--                interpret_reassoc_dir (step (branch l r) _ _ (cong_clos_step.left _ _ r f) fs) == 
+--                (to_lopsided l ⟨⊗⟩ C.identity (tensor_tree r)) ⟩C⟩ to_lopsided (branch l.lopsided r), from
+--         λ l' f fs,
+--         have e₀ : lopsided l = lopsided l', from
+--           by {apply reassoc_dir_step.respects_lopsided, assumption},
+--         have e₁ : lopsided (branch l r) = lopsided (branch l' r), from
+--           by {apply reassoc_dir_step.respects_lopsided, apply cong_clos_step.left, assumption},
+--         have e₂ : lopsided (branch l' r) = lopsided (branch (lopsided l') r), from
+--           by {unfold lopsided, congr_args, unfold to_list, rewrite from_list_lopsided_to_list},
+--         have e₃ : interpret_reassoc_dir fs == (interpret_reassoc_dir (reassoc_dir.reassoc_lopsided l') ⟨⊗⟩ C.identity (tensor_tree r)) ⟩C⟩ interpret_reassoc_dir (reassoc_dir.reassoc_lopsided (branch l'.lopsided r)), from
+--             calc
+--                   interpret_reassoc_dir fs
+--                 == interpret_reassoc_dir (rewrite_target e₁ fs)
+--                 :  by {congr_args, assumption, symmetry, apply rewrite_target_cong}
+--             ... =  interpret_reassoc_dir (trans_lopsided (cong_clos.inject_left r (reassoc_dir.reassoc_lopsided l')))
+--                 :  by apply directed_associator_coherence_thm (branch l' r) (branch l' r).lopsided (eq.refl _)
+--             ... == interpret_reassoc_dir (trans_lopsided' (cong_clos.inject_left r (reassoc_dir.reassoc_lopsided l')))
+--                 :  by {congr_args, assumption, apply trans_lopsided_heq}
+--             ... =  interpret_reassoc_dir (cong_clos.inject_left r (reassoc_dir.reassoc_lopsided l')) ⟩C⟩ interpret_reassoc_dir (reassoc_dir.reassoc_lopsided (branch l'.lopsided r))
+--                 :  by {symmetry, apply interpret_reassoc_dir_functoriality}
+--             ... =  (interpret_reassoc_dir (reassoc_dir.reassoc_lopsided l') ⟨⊗⟩ C.identity (tensor_tree r)) ⟩C⟩ interpret_reassoc_dir (reassoc_dir.reassoc_lopsided (branch l'.lopsided r))
+--                 :  by {congr_args, apply interpret_cong_clos_inject_left},
+--         calc
+--                 (interpret_reassoc_dir_step f ⟨⊗⟩ C.identity _) ⟩C⟩ interpret_reassoc_dir fs
+--             == (interpret_reassoc_dir_step f ⟨⊗⟩ C.identity _) ⟩C⟩ ((interpret_reassoc_dir (reassoc_dir.reassoc_lopsided l') ⟨⊗⟩ C.identity (tensor_tree r)) ⟩C⟩ interpret_reassoc_dir (reassoc_dir.reassoc_lopsided (branch l'.lopsided r)))
+--             :  by {congr_args, cc, assumption}
+--         ... == ((interpret_reassoc_dir_step f ⟨⊗⟩ C.identity _) ⟩C⟩ (interpret_reassoc_dir (reassoc_dir.reassoc_lopsided l') ⟨⊗⟩ C.identity (tensor_tree r))) ⟩C⟩ interpret_reassoc_dir (reassoc_dir.reassoc_lopsided (branch l'.lopsided r))
+--             :  ♮
+--         ... == ((interpret_reassoc_dir_step f ⟩C⟩ interpret_reassoc_dir (reassoc_dir.reassoc_lopsided l')) ⟨⊗⟩ C.identity (tensor_tree r)) ⟩C⟩ interpret_reassoc_dir (reassoc_dir.reassoc_lopsided (branch l'.lopsided r))
+--             :  by rewrite functoriality_left
+--         ... == (interpret_reassoc_dir (cong_clos.step _ _ _ f (reassoc_dir.reassoc_lopsided l')) ⟨⊗⟩ C.identity (tensor_tree r)) ⟩C⟩ interpret_reassoc_dir (reassoc_dir.reassoc_lopsided (branch l'.lopsided r))
+--             :  by reflexivity
+--         ... == (interpret_reassoc_dir (step_lopsided f) ⟨⊗⟩ C.identity (tensor_tree r)) ⟩C⟩ interpret_reassoc_dir (reassoc_dir.reassoc_lopsided (branch l.lopsided r))
+--             :  begin
+--                  congr_args,
+--                   {cc},
+--                   {cc},
+--                   {congr_args, cc, congr_args, cc, symmetry, apply step_lopsided_heq},
+--                   {cc}
+--                end
+--         ... = (to_lopsided l ⟨⊗⟩ C.identity (tensor_tree r)) ⟩C⟩ to_lopsided (branch l.lopsided r)
+--             :  by {congr_args, congr_args, apply directed_associator_coherence_thm l l.lopsided (eq.refl _)},
+--     eq_of_heq $
+--     calc
+--            interpret_reassoc_dir (step (branch l r) _ _ (cong_clos_step.left _ _ r p) ps)
+--         == (to_lopsided l ⟨⊗⟩ C.identity (tensor_tree r)) ⟩C⟩ to_lopsided (branch l.lopsided r)
+--         :  by apply H
+--     ... == interpret_reassoc_dir (step (branch l r) _ _ (cong_clos_step.left _ _ r q) qs)
+--         :  by {symmetry, apply H}
+-- | (branch l r) Ys e (cong_clos.step ._ ._ ._ (cong_clos_step.right ._ ._ rp p) ps) (cong_clos.step ._ ._ ._ (cong_clos_step.right ._ ._ rq q) qs) := sorry
+-- | (branch l r) Ys e (cong_clos.step ._ ._ ._ (cong_clos_step.left ._ lp ._ p) ps) (cong_clos.step ._ ._ ._ (cong_clos_step.right ._ ._ rq q) qs) := sorry
+-- | (branch l r) Ys e (cong_clos.step ._ ._ ._ (cong_clos_step.right ._ ._ rp p) ps) (cong_clos.step ._ ._ ._ (cong_clos_step.left ._ lq ._ q) qs) := sorry
+-- | (branch (branch x y) z) Ys e (cong_clos.step ._ ._ ._ (cong_clos_step.lift ._ ._ (reassoc_dir_single_step.rotate_right ._ ._ ._)) _) (cong_clos.step ._ _ ._ _ _) := sorry
+-- | (branch (branch x y) z) Ys e (cong_clos.step ._ _ ._ _ _) (cong_clos.step ._ ._ ._ (cong_clos_step.lift ._ ._ (reassoc_dir_single_step.rotate_right ._ ._ ._)) _) := sorry
+-- | Xs ._ e (cong_clos.refl ._ ._) (cong_clos.step ._ t' ._ q _) := sorry
+-- | Xs ._ e (cong_clos.step ._ t' ._ p _) (cong_clos.refl ._ ._) := sorry
+-- | Xs ._ e (cong_clos.refl ._ ._) (cong_clos.refl ._ ._) := sorry
+
+end interpretation
+
+end tqft.categories.monoidal_category.coherence_thm

--- a/util/data/bin_tree.lean
+++ b/util/data/bin_tree.lean
@@ -1,0 +1,53 @@
+import .nonempty_list
+
+open tqft.util.data.nonempty_list
+
+namespace tqft.util.data.bin_tree
+
+universes u v
+
+inductive bin_tree (α : Type u)
+| leaf : α → bin_tree
+| branch : bin_tree → bin_tree → bin_tree
+
+namespace bin_tree
+
+variables {α : Type u} {β : Type v}
+
+def map (f : α → β) : bin_tree α → bin_tree β
+| (leaf x) := leaf (f x)
+| (branch l r) := branch (map l) (map r)
+
+def to_list : bin_tree α → nonempty_list α
+| (leaf x) := nonempty_list.singleton x
+| (branch l r) := to_list l ++  to_list r
+
+def size : bin_tree α → ℕ
+| (leaf _) := 1
+| (branch l r) := size l + size r
+
+def from_list_lopsided : nonempty_list α → bin_tree α
+| (nonempty_list.singleton x) := leaf x
+| (nonempty_list.cons x xs)   := branch (leaf x) (from_list_lopsided xs)
+
+lemma from_list_lopsided_to_list : Π (l : nonempty_list α), to_list (from_list_lopsided l) = l
+| (nonempty_list.singleton x) := by reflexivity
+| (nonempty_list.cons x xs)   :=
+  begin
+    unfold from_list_lopsided,
+    unfold to_list,
+    rewrite from_list_lopsided_to_list xs,
+    reflexivity
+  end
+
+@[reducible] def lopsided (t : bin_tree α) : bin_tree α := from_list_lopsided t.to_list
+
+lemma lopsided_idempotent (t : bin_tree α) : t.lopsided.lopsided = t.lopsided :=
+  begin
+    unfold lopsided,
+    rewrite from_list_lopsided_to_list (to_list t)
+  end
+
+end bin_tree
+
+end tqft.util.data.bin_tree

--- a/util/data/bin_tree/cong_clos.lean
+++ b/util/data/bin_tree/cong_clos.lean
@@ -1,0 +1,162 @@
+import ..bin_tree
+import ..nonempty_list
+
+open tqft.util.data.nonempty_list
+open tqft.util.data.bin_tree
+open tqft.util.data.bin_tree.bin_tree
+
+universes u v
+
+variable {α : Type u}
+
+-- https://ncatlab.org/nlab/show/Mac+Lane%27s+proof+of+the+coherence+theorem+for+monoidal+categories
+
+-- TODO(tim): do we really need two definitions of the congruence closure or can we just delete this one?
+inductive cong_clos' (R : bin_tree α → bin_tree α → Type u) : bin_tree α → bin_tree α → Type u
+| lift : Π s t, R s t → cong_clos' s t
+| refl : Π t, cong_clos' t t
+| trans : Π r s t, cong_clos' r s → cong_clos' s t → cong_clos' r t
+| cong : Π l₁ r₁ l₂ r₂, cong_clos' l₁ l₂ → cong_clos' r₁ r₂ → cong_clos' (branch l₁ r₁) (branch l₂ r₂)
+
+namespace cong_clos'
+
+variable {R : bin_tree α → bin_tree α → Type u}
+
+def sym (R_sym : Π s t, R s t → R t s)
+    : Π {s t}, cong_clos' R s t → cong_clos' R t s
+| ._ ._ (lift _ _ p)       := lift _ _ (R_sym _ _ p)
+| ._ ._ (refl ._ t)        := refl R t
+| ._ ._ (trans _ _ _ p q)  := trans _ _ _ (sym q) (sym p)
+| ._ ._ (cong _ _ _ _ l r) := cong _ _ _ _ (sym l) (sym r)
+
+def transport {S : bin_tree α → bin_tree α → Type u} (f : Π s t, R s t → S s t)
+    : Π {s t}, cong_clos' R s t → cong_clos' S s t
+| ._ ._ (lift _ _ p)       := lift _ _ (f _ _ p)
+| ._ ._ (refl ._ t)        := refl S t
+| ._ ._ (trans _ _ _ p q)  := trans _ _ _ (transport p) (transport q)
+| ._ ._ (cong _ _ _ _ l r) := cong _ _ _ _ (transport l) (transport r)
+
+lemma respects_to_list (R_to_list : Π s t, R s t → s.to_list = t.to_list)
+    : Π {s t}, cong_clos' R s t → s.to_list = t.to_list
+| ._ ._ (lift _ _ p)           := R_to_list _ _ p
+| ._ ._ (refl ._ _)            := eq.refl _
+| ._ ._ (trans _ _ _ p q)      := eq.trans (respects_to_list p) (respects_to_list q)
+| ._ ._ (cong l₁ r₁ l₂ r₂ l r) :=
+    begin
+      unfold bin_tree.to_list,
+      rewrite (respects_to_list l),
+      rewrite (respects_to_list r)
+    end
+
+end cong_clos'
+
+inductive cong_clos_step (R : bin_tree α → bin_tree α → Type u) : bin_tree α → bin_tree α → Type u
+| lift  : Π s t, R s t → cong_clos_step s t
+| left  : Π l₁ l₂ r, cong_clos_step l₁ l₂ → cong_clos_step (branch l₁ r) (branch l₂ r)
+| right : Π l r₁ r₂, cong_clos_step r₁ r₂ → cong_clos_step (branch l r₁) (branch l r₂)
+
+namespace cong_clos_step
+
+variable {R : bin_tree α → bin_tree α → Type u}
+
+-- the equation compiler somehow can't handle the next definitions ~> turn it off
+-- TODO(tim): report bug
+set_option eqn_compiler.lemmas false
+
+def sym (R_sym : Π s t, R s t → R t s)
+    : Π {s t}, cong_clos_step R s t → cong_clos_step R t s
+| ._ ._ (lift _ _ p)    := lift _ _ (R_sym _ _ p)
+| ._ ._ (left _ _ _ l)  := left _ _ _ (sym l)
+| ._ ._ (right _ _ _ r) := right _ _ _ (sym r)
+
+def transport {S : bin_tree α → bin_tree α → Type u} (f : Π s t, R s t → S s t)
+    : Π {s t}, cong_clos_step R s t → cong_clos_step S s t
+| ._ ._ (lift _ _ p)    := lift _ _ (f _ _ p)
+| ._ ._ (left _ _ _ l)  := left _ _ _ (transport l)
+| ._ ._ (right _ _ _ r) := right _ _ _ (transport r)
+
+lemma respects_to_list (R_to_list : Π s t, R s t → s.to_list = t.to_list)
+    : Π {s t}, cong_clos_step R s t → s.to_list = t.to_list
+| ._ ._ (lift _ _ p)    := R_to_list _ _ p
+| ._ ._ (left _ _ _ l)  := by unfold bin_tree.to_list; rewrite (respects_to_list l)
+| ._ ._ (right _ _ _ r) := by unfold bin_tree.to_list; rewrite (respects_to_list r)
+
+lemma respects_lopsided
+    (R_to_list : Π s t, R s t → s.to_list = t.to_list)
+    {s t} (p : cong_clos_step R s t)
+    : s.lopsided = t.lopsided
+  := by unfold lopsided; rewrite respects_to_list R_to_list p
+
+set_option eqn_compiler.lemmas true
+
+end cong_clos_step
+
+-- smallest reflexive, transitive, congruent (but not necessarily symmetric) relation that includes R
+inductive cong_clos (R : bin_tree α → bin_tree α → Type u) : bin_tree α → bin_tree α → Type u
+| refl : Π t, cong_clos t t
+| step : Π r s t, cong_clos_step R r s → cong_clos s t → cong_clos r t
+
+namespace cong_clos
+
+variable {R : bin_tree α → bin_tree α → Type u}
+
+open cong_clos_step
+
+def lift {s t : bin_tree α} (p : R s t) : cong_clos R s t :=
+  step _ _ _ (cong_clos_step.lift _ _ p) (refl R _)
+
+def trans : Π {r s t : bin_tree α}, cong_clos R r s → cong_clos R s t → cong_clos R r t
+| ._ ._ _ (refl ._ t)       qs := qs
+| ._ ._ _ (step _ _ _ p ps) qs := step _ _ _ p (trans ps qs)
+
+lemma trans_refl_right : Π {s t : bin_tree α} (p : cong_clos R s t), trans p (refl R t) = p
+| ._ ._ (refl ._ t)       := by reflexivity
+| ._ ._ (step _ _ _ p ps) := by unfold trans; rewrite (trans_refl_right ps)
+
+def inject_left (r : bin_tree α) : Π {l₁ l₂ : bin_tree α}, cong_clos R l₁ l₂ → cong_clos R (branch l₁ r) (branch l₂ r)
+| ._ ._ (refl ._ t)       := refl R _
+| ._ ._ (step _ _ _ p ps) := step _ _ _ (left _ _ _ p) (inject_left ps)
+
+def inject_right (l : bin_tree α) : Π {r₁ r₂ : bin_tree α}, cong_clos R r₁ r₂ → cong_clos R (branch l r₁) (branch l r₂)
+| ._ ._ (refl ._ _)       := refl R _
+| ._ ._ (step _ _ _ p ps) := step _ _ _ (right _ _ _ p) (inject_right ps)
+
+def cong {l₁ l₂ r₁ r₂ : bin_tree α} (l : cong_clos R l₁ l₂) (r : cong_clos R r₁ r₂) : cong_clos R (branch l₁ r₁) (branch l₂ r₂) :=
+  trans (inject_left _ l) (inject_right _ r)
+
+def convert : Π (s t : bin_tree α), cong_clos' R s t → cong_clos R s t
+| ._ ._ (cong_clos'.refl ._ _)        := refl R _
+| ._ ._ (cong_clos'.lift _ _ p)       := lift p
+| ._ ._ (cong_clos'.trans _ _ _ p q)  := trans (convert _ _ p) (convert _ _ q)
+| ._ ._ (cong_clos'.cong _ _ _ _ l r) := cong (convert _ _ l) (convert _ _ r)
+
+def sym_helper (R_sym : Π s t, R s t → R t s)
+    : Π {s t u}, cong_clos R s t → cong_clos R s u → cong_clos R t u
+| ._ ._ _ (refl ._ t)       qs := qs
+| ._ ._ _ (step _ _ _ p ps) qs := sym_helper ps (step _ _ _ (cong_clos_step.sym R_sym p) qs)
+
+def sym (R_sym : Π s t, R s t → R t s) {s t} (ps : cong_clos R s t) : cong_clos R t s :=
+  sym_helper R_sym ps (refl R _)
+
+def transport {S : bin_tree α → bin_tree α → Type u} (f : Π s t, R s t → S s t)
+    : Π {s t}, cong_clos R s t → cong_clos S s t
+| ._ ._ (refl ._ t)       := refl S t
+| ._ ._ (step _ _ _ p ps) := step _ _ _ (cong_clos_step.transport f p) (transport ps)
+
+lemma respects_to_list (R_to_list : Π s t, R s t → s.to_list = t.to_list)
+    : Π {s t}, cong_clos R s t → s.to_list = t.to_list
+| ._ ._ (refl ._ t)       := by reflexivity
+| ._ ._ (step r s t p ps) :=
+  begin
+    transitivity,
+      exact (cong_clos_step.respects_to_list R_to_list p),
+      exact (respects_to_list ps)
+  end
+
+lemma respects_lopsided
+    (R_to_list : Π s t, R s t → s.to_list = t.to_list)
+    {s t} (p : cong_clos R s t)
+    : s.lopsided = t.lopsided
+  := by unfold lopsided; rewrite respects_to_list R_to_list p
+
+end cong_clos

--- a/util/data/nonempty_list.lean
+++ b/util/data/nonempty_list.lean
@@ -1,0 +1,59 @@
+namespace tqft.util.data.nonempty_list
+
+universe u
+variable {α : Type u}
+
+-- structure nonempty_list (α : Type u) :=
+--   (head : α)
+--   (tail : list α)
+
+inductive nonempty_list (α : Type u)
+| singleton : α → nonempty_list
+| cons : α → nonempty_list → nonempty_list
+
+namespace nonempty_list
+
+-- def singleton : α → nonempty_list α := λ x, { head := x, tail := [] }
+
+@[reducible] def head : nonempty_list α → α
+| (nonempty_list.singleton x) := x
+| (nonempty_list.cons x _)    := x
+
+@[reducible] def to_list : nonempty_list α → list α
+| (singleton x) := [x]
+| (cons x xs)   := x :: to_list xs
+
+@[reducible] def tail : nonempty_list α → list α
+| (singleton _) := []
+| (cons _ xs)   := to_list xs
+
+-- def append (xs : nonempty_list α) (ys : nonempty_list α) : nonempty_list α := {
+--   head := xs.head,
+--   tail := xs.tail ++ ys.to_list
+-- }
+
+def append : nonempty_list α → nonempty_list α → nonempty_list α
+| (singleton x) ys := cons x ys
+| (cons x xs)   ys := cons x (append xs ys)
+
+instance : has_append (nonempty_list α) := ⟨ append ⟩
+
+-- lemma append_assoc : Π (xs ys zs : nonempty_list α), append (append xs ys) zs = append xs (append ys zs) :=
+-- begin
+--   intros,
+--   unfold append,
+--   simp
+-- end
+
+@[simp] lemma singleton_append (x : α) (xs : nonempty_list α) : singleton x ++ xs = cons x xs :=
+rfl
+
+@[simp] lemma cons_append (x : α) (xs : nonempty_list α) (ys : nonempty_list α) : cons x xs ++ ys = cons x (xs ++ ys) :=
+rfl
+
+lemma append_assoc (xs ys zs : nonempty_list α) : (xs ++ ys) ++ zs = xs ++ (ys ++ zs) :=
+by induction xs; simph
+
+end nonempty_list
+
+end tqft.util.data.nonempty_list


### PR DESCRIPTION
I'm working towards proving the coherence theorem for monoidal categories. However, I think I can't prove the main lemma `directed_associator_coherence_thm` since

1. Lean lacks well-founded recursion (at the moment). Workaround: Use `meta lemma` instead of `lemma` to turn off the termination checker.
2. Lean thinks that there are missing cases (but won't tell me what they are). This is possibly related to https://github.com/leanprover/lean/issues/1466.

Even if these problems were fixed, I guess that it will still take a lot of work to finish the theorem Currently, only the first of multiple cases of [the proof](https://ncatlab.org/nlab/show/Mac+Lane%27s+proof+of+the+coherence+theorem+for+monoidal+categories#proof_of_version_2_of_the_coherence_theorem_vii21_of_cwm) is implemented.